### PR TITLE
challenges: by default use webroot, but also allow nginx auth plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,14 @@ Basic example playbook:
 Optional parameters
 ----------------
 
-| Variable      | Type          | Description  |
-| ------------- |:-------------:| ------------|
-| `certbot_auto_renew` | `boolean` | Whether to auto renew your certificate with a cron setup |
-| `certbot_deploy_hook`| `string`  | Command to execute after a successful renewed certificate. E.g. `/etc/init.d/nginx reload`. |
-| `certbot_host` | `string`        | Custom domain used to issue the certificate (if not provided defaults to `ansible_host`) |
-| `certbot_extra_hosts` | `array`  | A list of extra domains for which the certificate will be valid for (will provide a multi-domains certificate) |
-| `certbot_cert_name`   | `string` | The filename of the issued certificate by certbot. This will ensure your certificate is at `/etc/letsencrypt/live/{{ certbot_cert_name }}/fullchain.pem` path on your server. |
+| Variable                   | Type            | Description                                                                                                                                                                    |
+| -------------              | :-------------: | ------------                                                                                                                                                                   |
+| `certbot_auto_renew`       | `boolean`       | Whether to auto renew your certificate with a cron setup                                                                                                                       |
+| `certbot_deploy_hook`      | `string`        | Command to execute after a successful renewed certificate. E.g. `/etc/init.d/nginx reload`.                                                                                    |
+| `certbot_host`             | `string`        | Custom domain used to issue the certificate (if not provided defaults to `ansible_host`)                                                                                       |
+| `certbot_extra_hosts`      | `array`         | A list of extra domains for which the certificate will be valid for (will provide a multi-domains certificate)                                                                 |
+| `certbot_cert_name`        | `string`        | The filename of the issued certificate by certbot. This will ensure your certificate is at `/etc/letsencrypt/live/{{ certbot_cert_name }}/fullchain.pem` path on your server.  |
+| `certbot_challenge_method` | `string`        | Possible values: `webroot` or `nginx`. Method to use by certbot to perform challenge verification (webroot is if you already have a webserver, nginx if you don't have anyway) |
 
 
 Makefile for easier Ansible usage

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,4 +4,11 @@
 cerbot_agree_tos: ""
 certbot_admin_email: "admin@example.org"
 certbot_www_dir: "/var/www"
+
+# How to perform verification challenges
+# - by default use webroot directory to serve http challenges
+certbot_challenge_method: "webroot"
+# - If you don't have an existing web server you can use the nginx auth plugin instead
+# certbot_challenge_method: "nginx"
+
 certbot_auto_renew: false

--- a/tasks/get-cert.yml
+++ b/tasks/get-cert.yml
@@ -12,6 +12,19 @@
     state: directory
     path: "{{ certbot_www_dir }}"
 
-- name: Ask for a certificate from Lets Encrypt
+- name: Ask for a certificate from Lets Encrypt (webroot)
   shell: "yes | /opt/letsencrypt/certbot-auto certonly {{ certbot_agree_tos }} --webroot -w {{ certbot_www_dir }} --cert-name {{ certbot_cert_name }} -d {{ certbot_host | default(ansible_host) }}{% for extra_host in certbot_extra_hosts|default([]) %} -d {{ extra_host }} {% endfor %} --email {{ certbot_admin_email }}"
-  when: key_file.stat.islnk is not defined
+  when:
+    - key_file.stat.islnk is not defined
+    - certbot_challenge_method == "webroot"
+
+- name: Install nginx if needed
+  apt:
+    name: nginx
+  when: certbot_challenge_method == "nginx"
+
+- name: Ask for a certificate from Lets Encrypt (nginx plugin)
+  shell: "yes | /opt/letsencrypt/certbot-auto certonly {{ certbot_agree_tos }} --nginx --cert-name {{ certbot_cert_name }} -d {{ certbot_host | default(ansible_host) }}{% for extra_host in certbot_extra_hosts|default([]) %} -d {{ extra_host }} {% endfor %} --email {{ certbot_admin_email }}"
+  when:
+    - key_file.stat.islnk is not defined
+    - certbot_challenge_method == "nginx"


### PR DESCRIPTION
For now the role assumed you had a webserver which could serve a
webroot directory to perform verification challenge (when acquiring
certificates).

This PR adds a new method : `nginx` to use the cerbot nginx auth
plugin if you prefer.